### PR TITLE
Discrete axis

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Description: Provides curly braces in 'ggplot2' plus matching text.
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 URL: https://github.com/NicolasH2/ggbrace
 Suggests: 
     knitr,

--- a/R/StatBrace.R
+++ b/R/StatBrace.R
@@ -12,7 +12,8 @@ StatBrace <- ggplot2::ggproto(
     distance = NULL,
     outerstart = NULL,
     width = NULL,
-    outside = TRUE
+    outside = TRUE,
+    discreteAxis=FALSE
   ){
     x = data$x
     y = data$y
@@ -26,7 +27,8 @@ StatBrace <- ggplot2::ggproto(
       distance = distance,
       outerstart = outerstart,
       width = width,
-      outside = outside
+      outside = outside,
+      discreteAxis=discreteAxis
     )[["dataCoords"]]
 
     #provides data.frame with x and y values to draw the brace

--- a/R/coordCorrection.R
+++ b/R/coordCorrection.R
@@ -42,7 +42,6 @@
   #============================================#
   #==change coordinates (position and width)==#
   #============================================#
-  #outside is TRUE for stat_brace and FALSE for geom_brace
   if(outside){
     # change position
     if(is.null(distance)) distance <- diff(base)/50 #set distance to data points

--- a/R/coordCorrection.R
+++ b/R/coordCorrection.R
@@ -18,7 +18,8 @@
   distance,
   outerstart,
   width,
-  outside
+  outside,
+  discreteAxis=FALSE
 ){
   #to save if-statements, define 2 axes: a and b
   # a is the axis that is enclosed by the brace
@@ -52,6 +53,14 @@
     # b <- b + outerstart - ifelse(direction>0, min(b), max(b)) #change coordinates
     # # change width based on the original width
     # b[b == ifelse(direction>0, max(b), min(b))] <- width + ifelse(direction>0, min(b), max(b))
+  }
+
+  #============================#
+  #==discrete Axis adjustment==#
+  #============================#
+  if(discreteAxis){
+    radius=.45
+    a <- c(min(a,na.rm=T)-radius, a, max(a,na.rm=T)+radius)
   }
 
   #=============================#

--- a/R/stat_brace.R
+++ b/R/stat_brace.R
@@ -12,11 +12,12 @@
 #' @param rotate number, defines where the brace is pointing to: 0=up, 90=right, 180=down, 270=left. When specified by user, will overwrite other directions the brace might have from x/y coordinates.
 #' @param width number, how wide should the braces be? If NULL (default), will be determined automatically based on the data.
 #' @param mid number, where the pointer is within the bracket space (between 0.25 and 0.75). If NULL (default), will be determined automatically based on the data.
-#' @param outside boolean, should the brace be outside of the data area or cover the data area?
+#' @param outside boolean, should brace be outside of the data area or cover the data area?
 #' @param distance number, space between the brace and the nearest data point
 #' @param outerstart number, overwrites distance and provides one coordinate for all braces
 #' @param bending number, how strongly the curves of the braces should be bent (the higher the more round). Note: too high values will result in the brace showing zick-zack lines
 #' @param npoints integer, number of points generated for the brace curves (resolution). This number will be rounded to be a multiple of 4 for calculation purposes.
+#' @param discreteAxis boolean, does the embraced axis feature discrete values (often true for bar graphs)
 #' @return ggplot2 layer object (geom_path) that can directly be added to a ggplot2 object. If a label was provided, a another layer (geom_text) is added.
 #' @export
 #' @examples
@@ -66,11 +67,12 @@
 #'  coord_cartesian(y=range(iris$Sepal.Width), clip = "off") +
 #'  theme(plot.margin = unit(c(0.25, 0.11, 0.11, 0.11), units="npc"))
 #'
-#'  # braces with discrete values
-#'  df <- data.frame(x = c("a","b","c","d","e"), y = 1:5)
-#'  ggplot(df, aes(x, y)) +
-#'    geom_point() +
-#'    stat_brace(aes(x=seq_along(x)))
+#'  # braces with discrete axes
+#'  df <- iris
+#'  df$Group <- substring(iris$Species,1,1)
+#'  ggplot(df, aes(x=Species, y=Sepal.Length, group=Group)) +
+#'    geom_jitter() +
+#'    stat_brace(discreteAxis=TRUE)
 #'
 #'
 stat_brace <- function(
@@ -88,7 +90,8 @@ stat_brace <- function(
     bending = NULL,
     npoints = 100,
     show.legend = FALSE,
-    inherit.aes = TRUE
+    inherit.aes = TRUE,
+    discreteAxis=FALSE
 ){
   ggplot2::layer(
     data = data,
@@ -107,6 +110,7 @@ stat_brace <- function(
       outside = outside,
       distance = distance,
       outerstart = outerstart,
+      discreteAxis=discreteAxis,
       ...
     )
   )

--- a/man/dot-coordCorrection.Rd
+++ b/man/dot-coordCorrection.Rd
@@ -14,7 +14,8 @@ stats}
   distance,
   outerstart,
   width,
-  outside
+  outside,
+  discreteAxis = FALSE
 )
 }
 \arguments{
@@ -34,7 +35,9 @@ stats}
 
 \item{width}{number, how wide should the braces be? If NULL (default), will be determined automatically based on the data.}
 
-\item{outside}{boolean, should the brace be outside of the data area or cover the data area?}
+\item{outside}{boolean, should brace be outside of the data area or cover the data area?}
+
+\item{discreteAxis}{boolean, does the embraced axis feature discrete values (often true for bar graphs)}
 }
 \description{
 Imports:

--- a/man/stat_brace.Rd
+++ b/man/stat_brace.Rd
@@ -19,7 +19,8 @@ stat_brace(
   bending = NULL,
   npoints = 100,
   show.legend = FALSE,
-  inherit.aes = TRUE
+  inherit.aes = TRUE,
+  discreteAxis = FALSE
 )
 }
 \arguments{
@@ -43,19 +44,59 @@ the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
-\item{geom}{The geometric object to use to display the data, either as a
-\code{ggproto} \code{Geom} subclass or as a string naming the geom stripped of the
-\code{geom_} prefix (e.g. \code{"point"} rather than \code{"geom_point"})}
+\item{geom}{The geometric object to use to display the data for this layer.
+When using a \verb{stat_*()} function to construct a layer, the \code{geom} argument
+can be used to override the default coupling between stats and geoms. The
+\code{geom} argument accepts the following:
+\itemize{
+\item A \code{Geom} ggproto subclass, for example \code{GeomPoint}.
+\item A string naming the geom. To give the geom as a string, strip the
+function name of the \code{geom_} prefix. For example, to use \code{geom_point()},
+give the geom as \code{"point"}.
+\item For more information and other ways to specify the geom, see the
+\link[ggplot2:layer_geoms]{layer geom} documentation.
+}}
 
-\item{position}{Position adjustment, either as a string naming the adjustment
-(e.g. \code{"jitter"} to use \code{position_jitter}), or the result of a call to a
-position adjustment function. Use the latter if you need to change the
-settings of the adjustment.}
+\item{position}{A position adjustment to use on the data for this layer. This
+can be used in various ways, including to prevent overplotting and
+improving the display. The \code{position} argument accepts the following:
+\itemize{
+\item The result of calling a position function, such as \code{position_jitter()}.
+This method allows for passing extra arguments to the position.
+\item A string naming the position adjustment. To give the position as a
+string, strip the function name of the \code{position_} prefix. For example,
+to use \code{position_jitter()}, give the position as \code{"jitter"}.
+\item For more information and other ways to specify the position, see the
+\link[ggplot2:layer_positions]{layer position} documentation.
+}}
 
-\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
-often aesthetics, used to set an aesthetic to a fixed value, like
-\code{colour = "red"} or \code{size = 3}. They may also be parameters
-to the paired geom/stat.}
+\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}'s \code{params} argument. These
+arguments broadly fall into one of 4 categories below. Notably, further
+arguments to the \code{position} argument, or aesthetics that are required
+can \emph{not} be passed through \code{...}. Unknown arguments that are not part
+of the 4 categories below are ignored.
+\itemize{
+\item Static aesthetics that are not mapped to a scale, but are at a fixed
+value and apply to the layer as a whole. For example, \code{colour = "red"}
+or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
+section that lists the available options. The 'required' aesthetics
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
+\item When constructing a layer using
+a \verb{stat_*()} function, the \code{...} argument can be used to pass on
+parameters to the \code{geom} part of the layer. An example of this is
+\code{stat_density(geom = "area", outline.type = "both")}. The geom's
+documentation lists which parameters it can accept.
+\item Inversely, when constructing a layer using a
+\verb{geom_*()} function, the \code{...} argument can be used to pass on parameters
+to the \code{stat} part of the layer. An example of this is
+\code{geom_area(stat = "density", adjust = 0.5)}. The stat's documentation
+lists which parameters it can accept.
+\item The \code{key_glyph} argument of \code{\link[ggplot2:layer]{layer()}} may also be passed on through
+\code{...}. This can be one of the functions described as
+\link[ggplot2:draw_key]{key glyphs}, to change the display of the layer in the legend.
+}}
 
 \item{rotate}{number, defines where the brace is pointing to: 0=up, 90=right, 180=down, 270=left. When specified by user, will overwrite other directions the brace might have from x/y coordinates.}
 
@@ -63,7 +104,7 @@ to the paired geom/stat.}
 
 \item{mid}{number, where the pointer is within the bracket space (between 0.25 and 0.75). If NULL (default), will be determined automatically based on the data.}
 
-\item{outside}{boolean, should the brace be outside of the data area or cover the data area?}
+\item{outside}{boolean, should brace be outside of the data area or cover the data area?}
 
 \item{distance}{number, space between the brace and the nearest data point}
 
@@ -83,6 +124,8 @@ display.}
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
+
+\item{discreteAxis}{boolean, does the embraced axis feature discrete values (often true for bar graphs)}
 }
 \value{
 ggplot2 layer object (geom_path) that can directly be added to a ggplot2 object. If a label was provided, a another layer (geom_text) is added.
@@ -138,11 +181,12 @@ ggplot(iris, aes(x=Sepal.Length, y=Sepal.Width, color=Species, label=Species)) +
  coord_cartesian(y=range(iris$Sepal.Width), clip = "off") +
  theme(plot.margin = unit(c(0.25, 0.11, 0.11, 0.11), units="npc"))
 
- # braces with discrete values
- df <- data.frame(x = c("a","b","c","d","e"), y = 1:5)
- ggplot(df, aes(x, y)) +
-   geom_point() +
-   stat_brace(aes(x=seq_along(x)))
+ # braces with discrete axes
+ df <- iris
+ df$Group <- substring(iris$Species,1,1)
+ ggplot(df, aes(x=Species, y=Sepal.Length, group=Group)) +
+   geom_jitter() +
+   stat_brace(discreteAxis=TRUE)
 
 
 }

--- a/man/stat_bracetext.Rd
+++ b/man/stat_bracetext.Rd
@@ -42,19 +42,59 @@ the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
-\item{geom}{The geometric object to use to display the data, either as a
-\code{ggproto} \code{Geom} subclass or as a string naming the geom stripped of the
-\code{geom_} prefix (e.g. \code{"point"} rather than \code{"geom_point"})}
+\item{geom}{The geometric object to use to display the data for this layer.
+When using a \verb{stat_*()} function to construct a layer, the \code{geom} argument
+can be used to override the default coupling between stats and geoms. The
+\code{geom} argument accepts the following:
+\itemize{
+\item A \code{Geom} ggproto subclass, for example \code{GeomPoint}.
+\item A string naming the geom. To give the geom as a string, strip the
+function name of the \code{geom_} prefix. For example, to use \code{geom_point()},
+give the geom as \code{"point"}.
+\item For more information and other ways to specify the geom, see the
+\link[ggplot2:layer_geoms]{layer geom} documentation.
+}}
 
-\item{position}{Position adjustment, either as a string naming the adjustment
-(e.g. \code{"jitter"} to use \code{position_jitter}), or the result of a call to a
-position adjustment function. Use the latter if you need to change the
-settings of the adjustment.}
+\item{position}{A position adjustment to use on the data for this layer. This
+can be used in various ways, including to prevent overplotting and
+improving the display. The \code{position} argument accepts the following:
+\itemize{
+\item The result of calling a position function, such as \code{position_jitter()}.
+This method allows for passing extra arguments to the position.
+\item A string naming the position adjustment. To give the position as a
+string, strip the function name of the \code{position_} prefix. For example,
+to use \code{position_jitter()}, give the position as \code{"jitter"}.
+\item For more information and other ways to specify the position, see the
+\link[ggplot2:layer_positions]{layer position} documentation.
+}}
 
-\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
-often aesthetics, used to set an aesthetic to a fixed value, like
-\code{colour = "red"} or \code{size = 3}. They may also be parameters
-to the paired geom/stat.}
+\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}'s \code{params} argument. These
+arguments broadly fall into one of 4 categories below. Notably, further
+arguments to the \code{position} argument, or aesthetics that are required
+can \emph{not} be passed through \code{...}. Unknown arguments that are not part
+of the 4 categories below are ignored.
+\itemize{
+\item Static aesthetics that are not mapped to a scale, but are at a fixed
+value and apply to the layer as a whole. For example, \code{colour = "red"}
+or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
+section that lists the available options. The 'required' aesthetics
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
+\item When constructing a layer using
+a \verb{stat_*()} function, the \code{...} argument can be used to pass on
+parameters to the \code{geom} part of the layer. An example of this is
+\code{stat_density(geom = "area", outline.type = "both")}. The geom's
+documentation lists which parameters it can accept.
+\item Inversely, when constructing a layer using a
+\verb{geom_*()} function, the \code{...} argument can be used to pass on parameters
+to the \code{stat} part of the layer. An example of this is
+\code{geom_area(stat = "density", adjust = 0.5)}. The stat's documentation
+lists which parameters it can accept.
+\item The \code{key_glyph} argument of \code{\link[ggplot2:layer]{layer()}} may also be passed on through
+\code{...}. This can be one of the functions described as
+\link[ggplot2:draw_key]{key glyphs}, to change the display of the layer in the legend.
+}}
 
 \item{rotate}{number, defines where the brace is pointing to: 0=up, 90=right, 180=down, 270=left. When specified by user, will overwrite other directions the brace might have from x/y coordinates.}
 
@@ -62,7 +102,7 @@ to the paired geom/stat.}
 
 \item{mid}{number, where the pointer is within the bracket space (between 0.25 and 0.75). If NULL (default), will be determined automatically based on the data.}
 
-\item{outside}{boolean, should the brace be outside of the data area or cover the data area?}
+\item{outside}{boolean, should brace be outside of the data area or cover the data area?}
 
 \item{distance}{number, space between the brace and the nearest data point}
 


### PR DESCRIPTION
the new functionality allows user to specify that the embraced axis is discrete, which will adjust the braces to embrace the entire region of each discrete value, not just the point value itself